### PR TITLE
feat: add postgres check for required env variables.

### DIFF
--- a/Postgres/Dockerfile
+++ b/Postgres/Dockerfile
@@ -1,0 +1,6 @@
+FROM postgres:latest
+
+# Copy in entrypoint to check for required variables
+COPY entrypoint.sh /usr/local/bin/
+
+ENTRYPOINT ["entrypoint.sh"]

--- a/Postgres/entrypoint.sh
+++ b/Postgres/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+REQUIRED_VARIABLES="POSTGRES_USER POSTGRES_PASSWORD POSTGRES_DB"
+
+echo $POSTGRES_USER
+
+for var in $REQUIRED_VARIABLES; do
+    if [ -z "${!var}" ]; then
+        echo "ERROR: ${var} is unset."
+        exit 1
+    fi
+done;
+
+exec /usr/local/bin/docker-entrypoint.sh postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,20 @@
 services:
 
   db:
-    image: postgres:latest
-    restart: always
+    build: ./Postgres
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASS}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
     volumes:
       - asmr-db-data:/var/lib/postgresql/data
     ports:
       - "${DB_PORT}:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 2
 
 volumes:
   asmr-db-data:


### PR DESCRIPTION
Custom postgres container

Allows us to ensure the environment is as-expected before starting the database. Environment variables need to be set otherwise the container will exit.